### PR TITLE
Fix runtime package and tests

### DIFF
--- a/core_runtime/SeedEngine.py
+++ b/core_runtime/SeedEngine.py
@@ -42,8 +42,19 @@ class SeedMemory:
             data = json.load(f)
             return [Seed(**item) for item in data]
 
-    def get_active_seeds(self):
-        return [s for s in self.seeds if s.is_active()]
+    def get_active_seeds(self, context=None):
+        """Return all seeds that are currently active.
+
+        The optional ``context`` argument is accepted for compatibility with
+        callers that provide additional information. It is not used in the
+        default implementation.
+        """
+        active = [s for s in self.seeds if s.is_active()]
+        return [
+            {"id": s.id, "type": s.type, "intention": s.intention, "emotion": s.emotion}
+            for s in active
+        ]
 
     def find_seed(self, seed_id):
         return next((s for s in self.seeds if s.id == seed_id), None)
+

--- a/core_runtime/SeedPatternMatcher.py
+++ b/core_runtime/SeedPatternMatcher.py
@@ -13,6 +13,12 @@ class SeedPatternMatcher:
 
     def match_pattern(self, current_seed_ids):
         for pattern in self.patterns:
-            if pattern["Pattern"] == current_seed_ids:
+            if pattern.get("pattern") == current_seed_ids:
                 return pattern
         return None
+
+    def find_patterns(self, seeds):
+        """Return patterns matching the provided seeds."""
+        seed_ids = [s.get("id") for s in seeds]
+        match = self.match_pattern(seed_ids)
+        return [match] if match else []

--- a/core_runtime/__init__.py
+++ b/core_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Core runtime package."""


### PR DESCRIPTION
## Summary
- make `core_runtime` a package
- expose `SeedMemory.get_active_seeds` context parameter and return dictionaries
- implement `SeedPatternMatcher.find_patterns` and fix pattern lookup
- update `EvAIRuntime.generate_cot` to accept a params dict and work with new seed format
- adjust seed-handling helper methods
- ensure tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d620ae5dc83249ec77b71a5a5d20d