### PR TITLE
Enhance deployment readiness for frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,104 @@ EvAI streeft ernaar om continu te groeien, zichzelf te verbeteren en maximaal be
 
 ---
 
+## Local Development Setup
+
+To run EvAI locally, you'll need Python (for the backend) and Node.js (for the frontend) installed.
+
+### Backend (API)
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url>
+    cd <repository_name>
+    ```
+
+2.  **Navigate to the API directory:**
+    ```bash
+    cd api
+    ```
+
+3.  **Create and activate a Python virtual environment:**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    ```
+
+4.  **Install dependencies:**
+    ```bash
+    pip install -r ../requirements.txt
+    ```
+    *Note: The requirements.txt is in the root, so we use `../requirements.txt` from the `api` directory.*
+
+5.  **Configure environment variables:**
+    *   Copy the example environment file:
+        ```bash
+        cp .env.example .env
+        ```
+    *   Edit `.env` and provide the necessary values, especially for `API_KEY`. `ALLOWED_ORIGINS` defaults to allow `http://localhost:3000`.
+
+6.  **Run the backend server:**
+    The API uses Uvicorn and is configured in `main.py`.
+    ```bash
+    python main.py
+    ```
+    Or, directly with uvicorn from the `api` directory:
+    ```bash
+    uvicorn main:app --reload --port 8000
+    ```
+    The API should now be running on `http://localhost:8000`.
+
+### Frontend
+
+1.  **Navigate to the frontend directory (from the repository root):**
+    ```bash
+    cd frontend
+    ```
+
+2.  **Install Node.js dependencies:**
+    ```bash
+    npm install
+    ```
+
+3.  **Configure environment variables (optional for local development):**
+    *   The frontend will attempt to connect to `http://localhost:8000` by default.
+    *   If your backend is running on a different URL, copy the example environment file:
+        ```bash
+        cp .env.example .env
+        ```
+    *   Edit `.env` and set `REACT_APP_API_URL` to your backend's URL.
+
+4.  **Start the frontend development server:**
+    ```bash
+    npm start
+    ```
+    The frontend should now be running on `http://localhost:3000` (or another port if 3000 is busy) and open in your default web browser.
+
+---
+
+## Deployment
+
+This application is configured for deployment using [Render](https://render.com/) via the `render.yaml` file.
+
+### Environment Variables on Render
+
+When deploying to Render (or a similar platform), you will need to configure the following environment variables in your service settings:
+
+**For the `evai-backend` service:**
+
+*   `API_KEY`: **Required.** Your secret API key for accessing the backend.
+*   `ALLOWED_ORIGINS`: **Required.** A comma-separated list of allowed origins for CORS. For example: `https://your-frontend-app.onrender.com,http://localhost:3000` (if you still want to allow local development access).
+*   `PYTHON_VERSION`: (Already in `render.yaml`) Specifies the Python version.
+
+**For the `evai-frontend` service:**
+
+*   `REACT_APP_API_URL`: **Required.** The public URL of your deployed `evai-backend` service. For example: `https://your-backend-app.onrender.com`.
+*   `NODE_VERSION`: (Already in `render.yaml`) Specifies the Node.js version.
+
+Ensure these are set correctly in the Render dashboard for each service. The placeholders in `render.yaml` will be overridden by the values you set in the dashboard.
+
+---
+
 ## Changelog & Roadmap
 
 - Hier houd je wijzigingen, uitbreidingen en toekomstige plannen bij.

--- a/api/config.py
+++ b/api/config.py
@@ -1,10 +1,11 @@
 from pydantic_settings import BaseSettings
-from typing import Optional
+from typing import Optional, List
 
 class Settings(BaseSettings):
-    API_KEY: str = "your-secret-key-here"  # In production, use environment variable
+    API_KEY: str  # In production, use environment variable
     API_KEY_NAME: str = "X-API-Key"
     API_KEY_HEADER: str = "X-API-Key"
+    ALLOWED_ORIGINS: List[str] = ["http://localhost:3000"]
     
     class Config:
         env_file = ".env"

--- a/api/main.py
+++ b/api/main.py
@@ -14,7 +14,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 # CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, replace with specific origins
+    allow_origins=settings.ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/src/components/ChatInterface.js
+++ b/frontend/src/components/ChatInterface.js
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from 'react';
 import axios from 'axios';
 import ReactMarkdown from 'react-markdown';
 
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000';
+
 const ChatInterface = ({ onNewResponse }) => {
   const [messages, setMessages] = useState([]);
   const [input, setInput] = useState('');
@@ -27,7 +29,7 @@ const ChatInterface = ({ onNewResponse }) => {
     setIsLoading(true);
 
     try {
-      const response = await axios.post('http://localhost:8000/query', {
+      const response = await axios.post(`${API_URL}/query`, {
         text: input,
         context: {}
       });

--- a/render.yaml
+++ b/render.yaml
@@ -7,6 +7,8 @@ services:
     envVars:
       - key: NODE_VERSION
         value: 18.0.0
+      - key: REACT_APP_API_URL
+        value: https://your-backend-url.onrender.com # Placeholder
 
   - type: web
     name: evai-backend
@@ -15,4 +17,8 @@ services:
     startCommand: cd api && uvicorn main:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: PYTHON_VERSION
-        value: 3.9.0 
+        value: 3.9.0
+      - key: API_KEY
+        value: your_actual_api_key_to_be_set_in_render # Placeholder
+      - key: ALLOWED_ORIGINS
+        value: https://your-frontend-url.onrender.com # Placeholder for the deployed frontend URL


### PR DESCRIPTION
This commit introduces several changes to improve the deployment readiness of the EvAI application:

Backend:
- API_KEY is now loaded exclusively from environment variables, removing the default key from code.
- CORS allowed origins are now configurable via the `ALLOWED_ORIGINS` environment variable, defaulting to `http://localhost:3000`.
- Added `api/.env.example` to document required backend environment variables.

Frontend:
- The API URL in the frontend is now configurable via the `REACT_APP_API_URL` environment variable, defaulting to `http://localhost:8000` for local development.
- Added `frontend/.env.example` to document the frontend environment variable.

Deployment:
- Updated `render.yaml` to include placeholder environment variables (`API_KEY`, `ALLOWED_ORIGINS` for backend; `REACT_APP_API_URL` for frontend) that need to be set in the Render dashboard.

Documentation:
- Updated `README.md` with comprehensive "Local Development Setup" and "Deployment" sections, including details on environment variables.